### PR TITLE
Change default value of period setting to 1

### DIFF
--- a/src/main/java/com/discordlevelnotifications/LevelNotificationsConfig.java
+++ b/src/main/java/com/discordlevelnotifications/LevelNotificationsConfig.java
@@ -36,8 +36,8 @@ public interface LevelNotificationsConfig extends Config
 
 	@ConfigItem(
 			keyName = "periodLevel",
-			name = "send every n levels",
-			description = "Only levels that are a multiple of this value are sent. If 0, send every level"
+			name = "Send every n levels",
+			description = "Only levels that are a multiple of this value are sent. 99s are always sent"
 	)
-	default int periodLevel() {return 0;}
+	default int periodLevel() {return 1;}
 }

--- a/src/main/java/com/discordlevelnotifications/LevelNotificationsPlugin.java
+++ b/src/main/java/com/discordlevelnotifications/LevelNotificationsPlugin.java
@@ -121,11 +121,10 @@ public class LevelNotificationsPlugin extends Plugin
 	}
 
 	private boolean checkPeriodLevel(int level) {
-		if (config.periodLevel() == 0 || level == 99) {
+		if (level == 99) {
 			return true;
-		} else {
-			return level % config.periodLevel() == 0;
 		}
+		return level % config.periodLevel() == 0;
 	}
 
 	@Provides


### PR DESCRIPTION
The default value of 1 makes a bit more sense, as it intuitively does exactly what the default behaviour should be.