### PR TITLE
Fix multilevel message when using Level Interval

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ repositories {
 	mavenCentral()
 }
 
-def runeLiteVersion = '1.7.12'
+def runeLiteVersion = '1.7.26'
 
 dependencies {
 	compileOnly group: 'net.runelite', name:'client', version: runeLiteVersion
@@ -22,8 +22,8 @@ dependencies {
 	testImplementation group: 'net.runelite', name:'client', version: runeLiteVersion
 }
 
-group = 'com.example'
-version = '1.2.2'
+group = 'com.discordlevelnotifications'
+version = '1.2.3'
 sourceCompatibility = '1.8'
 
 tasks.withType(JavaCompile) {

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,1 +1,1 @@
-rootProject.name = 'example'
+rootProject.name = 'Discord-Level-Notifications'

--- a/src/main/java/com/discordlevelnotifications/LevelNotificationsPlugin.java
+++ b/src/main/java/com/discordlevelnotifications/LevelNotificationsPlugin.java
@@ -120,7 +120,7 @@ public class LevelNotificationsPlugin extends Plugin
 			currentLevels.put(skillName, newLevel);
 
 			// Certain activities can multilevel, check if any of the levels are valid for the message.
-			for (int level = previousLevel; level <= newLevel; level++)
+			for (int level = previousLevel + 1; level <= newLevel; level++)
 			{
 				if(shouldSendForThisLevel(level))
 				{

--- a/src/main/java/com/discordlevelnotifications/LevelNotificationsPlugin.java
+++ b/src/main/java/com/discordlevelnotifications/LevelNotificationsPlugin.java
@@ -105,23 +105,29 @@ public class LevelNotificationsPlugin extends Plugin
 	public void onStatChanged(net.runelite.api.events.StatChanged statChanged)
 	{
 		String skillName = statChanged.getSkill().getName();
-		int level = statChanged.getLevel();
+		int newLevel = statChanged.getLevel();
 
 		// .contains wasn't behaving so I went with == null
-		if (currentLevels.get(skillName) == null || currentLevels.get(skillName) == 0)
+		Integer previousLevel = currentLevels.get(skillName);
+		if (previousLevel == null || previousLevel == 0)
 		{
-			currentLevels.put(skillName, level);
+			currentLevels.put(skillName, newLevel);
 			return;
 		}
 
-		if (currentLevels.get(skillName) != level)
+		if (previousLevel != newLevel)
 		{
-			currentLevels.put(skillName, level);
+			currentLevels.put(skillName, newLevel);
 
-			if (shouldSendForThisLevel(level))
+			// Certain activities can multilevel, check if any of the levels are valid for the message.
+			for (int level = previousLevel; level <= newLevel; level++)
 			{
-				leveledSkills.add(skillName);
-				shouldSendMessage = true;
+				if(shouldSendForThisLevel(level))
+				{
+					leveledSkills.add(skillName);
+					shouldSendMessage = true;
+					break;
+				}
 			}
 		}
 	}

--- a/src/main/java/com/discordlevelnotifications/LevelNotificationsPlugin.java
+++ b/src/main/java/com/discordlevelnotifications/LevelNotificationsPlugin.java
@@ -147,7 +147,7 @@ public class LevelNotificationsPlugin extends Plugin
 
 	private void sendMessage()
 	{
-		String levelUpString = client.getLocalPlayer().getName();
+		String levelUpString = client.getLocalPlayer().getName() + " leveled ";
 
 		String[] skills = new String[leveledSkills.size()];
 		skills = leveledSkills.toArray(skills);
@@ -156,7 +156,6 @@ public class LevelNotificationsPlugin extends Plugin
 		for (int i = 0; i < skills.length; i++)
 		{
 			String skill = skills[i];
-			leveledSkills.remove(skill);
 			if (i > 0)
 			{
 				if (i == skills.length - 1)
@@ -169,7 +168,7 @@ public class LevelNotificationsPlugin extends Plugin
 				}
 			}
 
-			levelUpString += " leveled " + skill + " to " + currentLevels.get(skill);
+			levelUpString += skill + " to " + currentLevels.get(skill);
 		}
 
 		DiscordWebhookBody discordWebhookBody = new DiscordWebhookBody();


### PR DESCRIPTION
Since it only checked `shouldSendForThisLevel` for the new level, if you went from 3 > 8 with a level interval of 5, no message would be sent. It now loops the level difference and checks if one of 4,5,6,7,8(would pass at 5) is valid for the message.

Levelup messages are also modified to be as followed

> Name leveled Magic to 20
Name leveled Magic to 20, and Prayer to 5
Name leveled Magic to 20, Prayer to 5, and Strength to 30.